### PR TITLE
Fix(sprintf-js) remove regex match args for %{}

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,10 @@
 import React from 'react'
 
 import {
-  setDebug, 
   init, 
+  debug, 
   tct, 
-  tn, 
   t, 
-  __, 
 } from 'r-i18n'
 ```
 
@@ -24,28 +22,6 @@ Use [Jed](http://slexaxton.github.io/Jed) to initialize i18n in your project.
 init({ /* jed options */ })) 
 ```
 
-#### `translate` (alias `__`)
-
-```jsx
-import {__} from 'r-i18n'
-
-__('Welcome to Strikingly')  
-// -> '欢迎使用 Strikingly'
-
-__('Home|Welcome to Strikingly')  
-// remove namespace
-// -> '欢迎使用 Strikingly'
-
-__('Welcome to Strikingly. Click <a href="%{location}">here to continue</a>.', { location: 'http://www.strikingly.com/s/select_template' }) 
-// -> '欢迎使用 Strikingly。<a href="http://www.strikingly.com/s/select_template">按此继续</a>。'
-```
-
-### React
-
-Note that you need to use sprintf style templates (`'%{value}s'`) instead of simple interpolate `'%{value}'`.
-
-More info about sprintfjs: [link](https://github.com/alexei/sprintf.js).
-
 #### `t`
 
 Component as placeholder
@@ -53,13 +29,18 @@ Component as placeholder
 ```jsx
 import {t} from 'r-i18n'
 
-//...
+t('Welcome to Strikingly')  
+// -> '欢迎使用 Strikingly'
 
-t('%{author}s assigned this event to %{assignee}s', {
+t('Welcome to Strikingly. Click <a href="%{location}">here to continue</a>.', { location: 'http://www.strikingly.com/s/select_template' }) 
+// -> '欢迎使用 Strikingly。<a href="http://www.strikingly.com/s/select_template">按此继续</a>。'
+
+// React component as placeholder
+
+t('%{author} assigned this event to %{assignee}', {
   author: <Author value={author} />,
   assignee: <em>example@example.com</em>
 })
-// React components
 // -> [<Author value={author} />, ' assigned this event to ', <em>example@example.com</em>]
 ```
 
@@ -84,11 +65,11 @@ tct('Welcome. Click [link:here]', {
 Wrap `t` and `tct` with a wrapper `<span class="translation-wrapper"/>`
 
 ```jsx
-import {tct, setDebug} from 'r-i18n'
+import {tct, debug} from 'r-i18n'
 
 //...
 
-setDebug()
+debug()
 
 tct('Welcome. Click [link:here]', {
   root: <p/>,

--- a/index.js
+++ b/index.js
@@ -2,43 +2,9 @@
 
 import Jed from 'jed'
 import _ from 'lodash'
-import {_gettext, t as _t, tn, tct, setLocale, setDebug} from './src/i18n'
+import {setLocale, setDebug, tct, tn, t} from './src/i18n'
 
 const init = (m) => setLocale(new Jed(m))
+const debug = setDebug
 
-const removeNamespace = (message) => {
-  if (_.isString(message)) {
-    return message.replace(/^[^\s]*\|/, '')
-  } else {
-    return message
-  }
-}
-
-const t = (message, values) => removeNamespace(gettext(message, values))
-
-const __ = (message, values={}) => removeNamespace(interpolate(_gettext(message), values))
-
-const interpolate = (message, values={}) =>
-  _.template(message, {interpolate: /%\{([\s\S]+?)\}/})(values)
-
-const gettext = (message, values={}) => {
-  if (typeof __SERVER_RENDERING__ !== 'undefined') {
-    return message
-  }
-  try {
-    return _t(message, values)
-  } catch (e) {
-    if (process.env.NODE_ENV != 'production') {
-      throw e
-    }
-    if (Bugsnag) {
-      Bugsnag.notifyException(e, "I18n.jed")
-    }
-    return ''
-  }
-}
-
-const ngettext = tn
-const translate = __
-
-export {init, setDebug, translate, removeNamespace, gettext, ngettext, tct, tn, t, __}
+export {init, debug, tct, tn, t}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -83,7 +83,7 @@ function argsInvolveReact(args) {
   return false;
 }
 
-export function parseComponentTemplate(string) {
+function parseComponentTemplate(string) {
   let rv = {};
 
   function process(startPos, group, inGroup) {
@@ -135,7 +135,7 @@ export function parseComponentTemplate(string) {
   return rv;
 }
 
-export function renderComponentTemplate(template, components) {
+function renderComponentTemplate(template, components) {
   let idx = 0;
 
   function renderGroup(group) {
@@ -191,7 +191,11 @@ function mark(rv) {
   return proxy;
 }
 
-export function format(formatString, args) {
+function cacheGettext(string) {
+  return _cache[string] || (_cache[string] = i18n.gettext(string));
+}
+
+function format(formatString, args) {
   if (argsInvolveReact(args)) {
     return formatForReact(formatString, args);
   } else {
@@ -199,14 +203,10 @@ export function format(formatString, args) {
   }
 }
 
-export function _gettext(string) {
-  return _cache[string] || (_cache[string] = i18n.gettext(string));
-}
-
 export function gettext(string, ...args) {
-  let rv = _gettext(string);
+  let rv = cacheGettext(string);
   if (args.length > 0) {
-    rv = format(rv, args);
+  	rv = format(rv, args)
   }
   return mark(rv);
 }

--- a/src/sprintf-js-mod.js
+++ b/src/sprintf-js-mod.js
@@ -6,7 +6,7 @@
     not_json: /[^j]/,
     text: /^[^\x25]+/,
     modulo: /^\x25{2}/,
-    placeholder: /^\x25(?:([1-9]\d*)\$|\{([^\}]+)\})?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-gijosuxX])/,
+    placeholder: /^\x25(?:([1-9]\d*)\$|\{([^\}]+)\})?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?/,
     key: /^([a-z_][a-z_\d]*)/i,
     key_access: /^\.([a-z_][a-z_\d]*)/i,
     index_access: /^\[(\d+)\]/,
@@ -50,6 +50,8 @@
           arg = arg()
         }
 
+		arg = ((arg = String(arg)) && match[7] ? arg.substring(0, match[7]) : arg)
+		/*
         if (re.not_string.test(match[8]) && re.not_json.test(match[8]) && (get_type(arg) != "number" && isNaN(arg))) {
           throw new TypeError(sprintf("[sprintf] expecting number but found %s", get_type(arg)))
         }
@@ -97,22 +99,12 @@
             arg = arg.toString(16).toUpperCase()
             break
         }
-        if (re.json.test(match[8])) {
-          output[output.length] = arg
-        }
-        else {
-          if (re.number.test(match[8]) && (!is_positive || match[3])) {
-            sign = is_positive ? "+" : "-"
-            arg = arg.toString().replace(re.sign, "")
-          }
-          else {
-            sign = ""
-          }
-          pad_character = match[4] ? match[4] === "0" ? "0" : match[4].charAt(1) : " "
-          pad_length = match[6] - (sign + arg).length
-          pad = match[6] ? (pad_length > 0 ? str_repeat(pad_character, pad_length) : "") : ""
-          output[output.length] = match[5] ? sign + arg + pad : (pad_character === "0" ? sign + pad + arg : pad + sign + arg)
-        }
+        */
+
+        pad_character = match[4] ? match[4] === "0" ? "0" : match[4].charAt(1) : " "
+        pad_length = match[6] - arg.length
+        pad = match[6] ? (pad_length > 0 ? str_repeat(pad_character, pad_length) : "") : ""
+        output[output.length] = match[5] ? arg + pad : (pad_character === "0" ? sign + pad + arg : pad + arg)
       }
     }
     return output.join("")

--- a/test/test.js
+++ b/test/test.js
@@ -15,28 +15,23 @@ describe('i18n', () => {
     assert(i18n.t('lorem ipsum') === 'lorem ipsum')
     // returns 'lorem ipsum'
 
-    assert(i18n.t('settings|lorem ipsum') === 'lorem ipsum')
-    // returns 'lorem ipsum'
-
-    assert(i18n.t('%{li}s', {li: <p>lorem ipsum</p>})[0].$$typeof === Symbol.for('react.element'))
+    assert(i18n.t('%{li}', {li: <p>lorem ipsum</p>})[0].$$typeof === Symbol.for('react.element'))
     // returns [<p>lorem ipsum</p>]
 
-    assert(i18n.t('lorem %{li}s ipsum', {li: <p>lorem ipsum</p>}).length === 3)
+    assert(i18n.t('lorem %{li} ipsum', {li: <p>lorem ipsum</p>}).length === 3)
     // returns ['lorem', <p>lorem ipsum</p>, 'ipsum']
   })
 
   it('should return templated strings', () => {
-    assert(i18n.t('%{l}s', {l: 'lorem'}) === 'lorem');
-    assert(i18n.t('%{l}s %{i}s', {
+    assert(i18n.t('%{l}', {l: 'lorem'}) === 'lorem')
+    assert(i18n.t('%{l} %{i}', {
         l: 'lorem',
         i: 'ipsum'
-      }) === 'lorem ipsum');
-    assert(i18n.t('%{li}j', {li: ['lorem', 'ipsum']}) === '["lorem","ipsum"]')
-
-    assert(i18n.t('%{author}s assigned this event to %{assignee}s', {
+      }) === 'lorem ipsum')
+    assert(i18n.t('%{author} assigned this event to %{assignee}', {
       author: <p>example</p>,
       assignee: <em>example@example.com</em>
-    }))
+    })[1] === ' assigned this event to ')
   })
 
   it('should return wrapped react components', () => {
@@ -64,9 +59,7 @@ describe('i18n', () => {
     })
 
     assert(i18n.t('hello') === 'bonjour')
-  })
 
-  it('should works with __', () => {
     i18n.init({
       'domain': 'i18n',
       'missing_key_callback': function (key) {
@@ -78,18 +71,16 @@ describe('i18n', () => {
             'lang': 'fr',
             'plural_forms': 'nplurals=2; plural=(n != 1);'
           },
-          'hello %{name}': ['bonjour %{name}'],
-          'main|hello %{name}': ['bonjour %{name}!!!']
+          'hello %{name}': ['bonjour %{name}']
         }
       }
     })
 
-    assert(i18n.__('hello %{name}', {name: 'world'}) === 'bonjour world')
-    assert(i18n.__('main|hello %{name}', {name: 'world'}) === 'bonjour world!!!')
+    assert(i18n.t('hello %{name}', {name: 'world'}) === 'bonjour world')
   })
 
   it('should return debugging wrapper', () => {
-    i18n.setDebug()
+    i18n.debug()
     assert(ReactDOMServer.renderToStaticMarkup(i18n.tct('lorem [li] ipsum', {
         root: <div/>,
         li: <b>hey</b>


### PR DESCRIPTION
- %{}s -> %{}
- simplify exported methods
